### PR TITLE
activity helper function exist or not checking updated

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,7 +2,7 @@
 
 use Shipu\Watchable\Utility\ActivityLogger;
 
-if(function_exists('activity')) {
+if(!function_exists('activity')) {
     function activity() {
         return app(ActivityLogger::class);
     }


### PR DESCRIPTION
Activity helper function was only being defined if "activity" function already exist.
It should be the opposite, activity function should be defined if function does not exist.